### PR TITLE
Only use required Bevy features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,12 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-bevy = "0.10"
+bevy = { version = "0.10", default-features = false, features = ["bevy_render", "bevy_asset", "bevy_pbr", "bevy_core_pipeline", "bevy_scene", "bevy_gltf"] }
 image = "0.24"
 futures-lite = "1.12"
+
+[dev-dependencies]
+bevy = { version = "0.10" }
 
 # Enable optimization in debug mode
 [profile.dev]


### PR DESCRIPTION
Makes it possible to use with bevy_kira_audio which requires some Bevy's features be disabled.