### PR TITLE
Turn off default features for image

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ bevy = { version = "0.16", default-features = false, features = [
     "jpeg",
     "multi_threaded",
 ] }
-image = "0.25"
+image = { version = "0.25", default-features = false }
 futures-lite = "2.6"
 intel_tex_2 = { version = "0.4.0", optional = true }
 zstd = { version = "0.13.2", optional = true }


### PR DESCRIPTION
By default `image` pulls in deps for various formats, most of which won't be used in a bevy project. Users can turn on bevy features for the file formats they want to support so I don't think there's any reason for this project to need them specify them.