### PR TITLE
bevy18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,21 +8,19 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 bevy = { version = "0.18.0-rc.1", default-features = false, features = [
-    "bevy_render",
     "bevy_asset",
-    "bevy_pbr",
-    "bevy_core_pipeline",
     "bevy_scene",
-    "bevy_gltf",
-    "tonemapping_luts",
+    "bevy_pbr",
     "ktx2",
     "jpeg",
     "multi_threaded",
 ] }
 image = { version = "0.25", default-features = false }
 futures-lite = "2.6"
+tracing = "0.1"
 intel_tex_2 = { version = "0.4.0", optional = true }
 zstd = { version = "0.13.2", optional = true }
+
 
 [dev-dependencies]
 bevy = { version = "0.18.0-rc.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-bevy = { version = "0.18.0-rc.1", default-features = false, features = [
+bevy = { version = "0.18", default-features = false, features = [
     "bevy_asset",
     "bevy_scene",
     "bevy_pbr",
@@ -24,7 +24,7 @@ zstd = { version = "0.13.2", optional = true }
 
 
 [dev-dependencies]
-bevy = { version = "0.18.0-rc.1" }
+bevy = { version = "0.18" }
 
 # Enable optimization in debug mode
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-bevy = { version = "0.17", default-features = false, features = [
+bevy = { version = "0.18.0-rc.1", default-features = false, features = [
     "bevy_render",
     "bevy_asset",
     "bevy_pbr",
@@ -25,7 +25,7 @@ intel_tex_2 = { version = "0.4.0", optional = true }
 zstd = { version = "0.13.2", optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.17" }
+bevy = { version = "0.18.0-rc.1" }
 
 # Enable optimization in debug mode
 [profile.dev]
@@ -36,10 +36,12 @@ opt-level = 1
 opt-level = 3
 
 [features]
-default = ["debug_text"]
+default = ["debug_text", "bevy_zstd_rust"]
 compress = ["dep:intel_tex_2", "dep:zstd"]
 debug_text = ["bevy/bevy_ui"]
 pbr_transmission_textures = ["bevy/pbr_transmission_textures"]
 pbr_multi_layer_material_textures = ["bevy/pbr_multi_layer_material_textures"]
 pbr_anisotropy_texture = ["bevy/pbr_anisotropy_texture"]
 pbr_specular_textures = ["bevy/pbr_specular_textures"]
+bevy_zstd_rust = ["bevy/zstd_rust"]
+bevy_zstd_c = ["bevy/zstd_c"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ bevy = { version = "0.18.0-rc.1", default-features = false, features = [
     "multi_threaded",
 ] }
 image = { version = "0.25", default-features = false }
+fast_image_resize = { version = "5.4", features = ["image"] }
 futures-lite = "2.6"
 tracing = "0.1"
 intel_tex_2 = { version = "0.4.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bevy_mod_mipmap_generator
 
-## A basic mipmap generator for bevy 0.17.
+## A basic mipmap generator for bevy 0.18.
 
 Optionally use the `compress` feature and corresponding setting in `MipmapGeneratorSettings` to enable BCn compression. Note: Compression can take a long time depending on the quantity and resolution of the images.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -497,13 +497,16 @@ pub fn generate_mips(
         let mut compressed_image_data = None;
         #[cfg(feature = "compress")]
         if let Some(compression_speed) = settings.compression {
-            compressed_image_data = bcn_compress_dyn_image(
-                compression_speed,
-                dyn_image,
-                has_alpha,
-                settings.low_quality,
-            )
-            .ok();
+            // https://github.com/bevyengine/bevy/issues/21490
+            if width >= 4 && height >= 4 {
+                compressed_image_data = bcn_compress_dyn_image(
+                    compression_speed,
+                    dyn_image,
+                    has_alpha,
+                    settings.low_quality,
+                )
+                .ok();
+            }
         }
         image_data.append(&mut compressed_image_data.unwrap_or(dyn_image.as_bytes().to_vec()));
         if width <= min || height <= min {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use anyhow::anyhow;
+use tracing::warn;
 
 use bevy::{
     asset::RenderAssetUsages,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use anyhow::anyhow;
+use fast_image_resize::{ResizeAlg, ResizeOptions, Resizer};
 use tracing::warn;
 
 use bevy::{
@@ -436,7 +437,7 @@ pub fn generate_mips_texture(
 /// Use `calculate_mip_count()` to find the value for `mip_count`.
 pub fn generate_mips(
     dyn_image: &mut DynamicImage,
-    #[allow(unused_variables)] has_alpha: bool,
+    has_alpha: bool,
     mip_count: u32,
     settings: &MipmapGeneratorSettings,
 ) -> Vec<u8> {
@@ -468,10 +469,29 @@ pub fn generate_mips(
     #[cfg(not(feature = "compress"))]
     let min = 1;
 
+    let mut resizer = Resizer::new();
+
+    let resize_alg = ResizeOptions::new()
+        .resize_alg(match settings.filter_type {
+            FilterType::Nearest => ResizeAlg::Nearest,
+            FilterType::Triangle => ResizeAlg::Convolution(fast_image_resize::FilterType::Bilinear),
+            FilterType::CatmullRom => {
+                ResizeAlg::Convolution(fast_image_resize::FilterType::CatmullRom)
+            }
+            FilterType::Gaussian => ResizeAlg::Convolution(fast_image_resize::FilterType::Gaussian),
+            FilterType::Lanczos3 => ResizeAlg::Convolution(fast_image_resize::FilterType::Lanczos3),
+        })
+        .use_alpha(has_alpha);
+
     for _ in 0..mip_count {
         width /= 2;
         height /= 2;
-        *dyn_image = dyn_image.resize_exact(width, height, settings.filter_type);
+
+        // *dyn_image = dyn_image.resize_exact(width, height, settings.filter_type); // Ex: Resizing with Image crate
+
+        let mut new = DynamicImage::new(width, height, dyn_image.color());
+        resizer.resize(dyn_image, &mut new, &resize_alg).unwrap();
+        *dyn_image = new;
 
         #[allow(unused_mut)]
         let mut compressed_image_data = None;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -532,7 +532,7 @@ pub fn extract_mip_level(image: &Image, mip_level: u32) -> anyhow::Result<Image>
 
     if descriptor.mip_level_count < mip_level {
         return Err(anyhow!(
-            "Mip level {mip_level} requested, but only {} are avaliable.",
+            "Mip level {mip_level} requested, but only {} are available.",
             descriptor.mip_level_count
         ));
     }


### PR DESCRIPTION
Seems to be an issue in 0.18.0-rc.1 where the image data is updated but that change is not reflected in the displayed texture.

Yep: https://github.com/bevyengine/bevy/issues/22212

This PR also switches to using https://github.com/cykooz/fast_image_resize for resizing which appears to be between 4x and 10x as fast as the resize provided by the Image crate. (When tested with `bevy_mod_mipmap_generator`)